### PR TITLE
Feature/TECH-725 Add widget-configuration-pull script

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "test": "npx jest",
     "stylelint": "npx stylelint **/*.scss",
     "stylelint:fix": "npx stylelint --fix **/*.scss",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "pull-widget-content": "node scripts/pull-widgets"
   },
   "prettier": "@trelliscommerce/prettier-config",
   "lint-staged": {

--- a/scripts/client.js
+++ b/scripts/client.js
@@ -1,0 +1,127 @@
+/**
+ * @typedef {{
+ *     method?: 'get' | 'post' | 'put' | 'delete'
+ *     body?: any
+ *     queries?: Record<string, any>
+ *     raw?: boolean
+ * }} FetchParameters
+ */
+
+class BigCommerceStore {
+  hash;
+  token;
+  verbose;
+
+  /**
+   * @param {string} hash
+   * @param {string} token
+   * @param {boolean} verbose
+   */
+  constructor(hash, token, { verbose } = {}) {
+    this.hash = hash;
+    this.token = token;
+    this.verbose = verbose;
+  }
+
+  /**
+   * @param {string} endpoint
+   * @param {FetchParameters} params
+   */
+  async fetch(endpoint, params) {
+    const url = new URL(
+      `https://api.bigcommerce.com/stores/${this.hash}/${endpoint}`,
+    );
+    Object.entries(params?.queries ?? {}).forEach(([name, value]) => {
+      url.searchParams.append(name, value);
+    });
+    const headers = {
+      accept: 'application/json',
+      'x-auth-token': this.token,
+    };
+    if (params?.body) headers['content-type'] = 'application/json';
+    let request;
+    for (let tries = 0; tries < 3; tries++) {
+      request = await fetch(url, {
+        method: params?.method,
+        body: params?.body ? JSON.stringify(params.body) : undefined,
+        headers,
+      });
+      if (this.verbose)
+        console.log(
+          `${(params?.method ?? 'get').toUpperCase()} ${url.toString()} - ${
+            request.status
+          } ${request.statusText}`,
+        );
+      if (!request.ok) {
+        if (request.status >= 500) continue;
+        else break;
+      }
+      if (request.status === 204) return;
+      const result = await request.json();
+      if (result.data && !params?.raw) return result.data;
+      return result;
+    }
+    throw new Error(
+      `BigCommerce fetch error - ${(params?.method ?? 'get').toUpperCase()} ${
+        request.status
+      } ${request.statusText} ${await request.text()}`,
+    );
+  }
+
+  /**
+   * @param {string} endpoint
+   * @param {FetchParameters} params
+   */
+  async get(endpoint, params) {
+    return this.fetch(endpoint, { ...params, method: 'get' });
+  }
+
+  /**
+   * @param {string} endpoint
+   * @param {FetchParameters} params
+   */
+  async getAll(endpoint, params) {
+    const results = [];
+    let total_pages = 1;
+    for (let page = 1; page <= total_pages; page++) {
+      const current = await this.fetch(endpoint, {
+        ...params,
+        queries: {
+          ...(params?.queries ?? {}),
+          page,
+        },
+        raw: true,
+      });
+      if (current?.meta?.pagination?.total_pages)
+        total_pages = current?.meta?.pagination?.total_pages;
+      results.push(...(current?.data ? current.data : current));
+    }
+    return results;
+  }
+
+  /**
+   * @param {string} endpoint
+   * @param {FetchParameters} params
+   */
+  async post(endpoint, params) {
+    return this.fetch(endpoint, { ...params, method: 'post' });
+  }
+
+  /**
+   * @param {string} endpoint
+   * @param {FetchParameters} params
+   */
+  async put(endpoint, params) {
+    return this.fetch(endpoint, { ...params, method: 'put' });
+  }
+
+  /**
+   * @param {string} endpoint
+   * @param {FetchParameters} params
+   */
+  async delete(endpoint, params) {
+    return this.fetch(endpoint, { ...params, method: 'delete' });
+  }
+}
+
+module.exports = BigCommerceStore;

--- a/scripts/pull-widgets.js
+++ b/scripts/pull-widgets.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const BigCommerceStore = require('./client');
+
+async function main() {
+  if (
+    !fs.existsSync('secrets.stencil.json') ||
+    !fs.existsSync('config.stencil.json')
+  )
+    throw new Error('Configuration is missing, run `stencil init` first.');
+
+  const token = JSON.parse(
+    fs.readFileSync('secrets.stencil.json', 'utf8'),
+  ).accessToken;
+
+  const storeUrl = new URL(
+    JSON.parse(fs.readFileSync('config.stencil.json', 'utf8')).normalStoreUrl,
+  );
+  const hash = storeUrl.hostname.split('.')[0].split('-')[1];
+
+  const store = new BigCommerceStore(hash, token);
+
+  try {
+    await store.get('v2/store');
+  } catch (e) {
+    throw new Error(
+      'Hash or token are invalid. Ensure "normalStoreUrl" within config.stencil.json uses "store-XXX.mybigcommerce" formatted URL. API token must have widget, theme & information access.',
+    );
+  }
+
+  const widgetContent = (await store.getAll('v3/content/widgets')).map(
+    ({ widget_configuration }) => widget_configuration,
+  );
+
+  fs.writeFileSync(
+    'widgets/content.json',
+    JSON.stringify(widgetContent, null, 2),
+  );
+}
+
+main();


### PR DESCRIPTION
#### What?

Add widget configuration pull script so that Tailwind can register classnames used within pagebuilder fields.

#### Tickets / Documentation

https://growwithtrellis.atlassian.net/browse/TECH-725

Requires developer to use the following values when running `stencil init`:
- https://store-{HASH}.mybigcommerce.com/ style URL
- An API token with the following permissions:
  - Content - Modify
  - Information - Read
  - Theme - Modify
  - Site - Read

The idea here would be for the dev to use a single token for `stencil` commands, as well as API ops.
